### PR TITLE
:arrow_up: :racehorse: add stage-1 preset, split build into vendor/bundle

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": [
     "es2015",
-    "react"
+    "react",
+    "stage-1"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 web/build/bundle.js
+web/build/vendor.js
 web/build/style.css

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "description": "yet another react stub project",
   "scripts": {
-    "watch": "watchify -p [ css-modulesify -o web/build/style.css ] -t babelify src/main.js -o web/build/bundle.js -d -v",
+    "build:vendor": "browserify -r react -r react-dom -o web/build/vendor.js",
+    "watch": "npm run build:vendor && watchify -p [ css-modulesify -o web/build/style.css ] -x react -x react-dom -t babelify src/main.js -o web/build/bundle.js -d -v",
     "start": "http-server web -o",
     "typecheck": "flow"
   },
@@ -12,7 +13,7 @@
     "url": "https://github.com/nsfmc/vernon.git"
   },
   "author": "Marcos Ojeda <marcos@generic.cx> (http://generic.cx/)",
-  "license": "CC0-1.0",
+  "license": "MIT",
   "dependencies": {
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",
+    "babel-preset-stage-1": "^6.5.0",
     "css-modulesify": "^0.24.0",
     "eslint": "^2.11.1",
     "eslint-config-standard": "^5.3.1",

--- a/web/index.html
+++ b/web/index.html
@@ -11,6 +11,7 @@
 
 <div id="mountpoint"></div>
 
+<script src="build/vendor.js"></script>
 <script src="build/bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
this allows static properties on ES6 react classes and will make
watched builds go a bit faster at the expense of needing to restart the
`npm run watch` command each time react and react-dom are upgraded.
